### PR TITLE
Add ForestHub.ai under Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ A curated list of hardware, software, frameworks and other resources for Artific
 - [micro:bit CreateAI](https://createai.microbit.org/) - Web-based tool to train an ML model and then run it on a BBC micro:bit V2.
 - [AutoML VS Code Extension](https://github.com/analogdevicesinc/automl-embedded) - Open Source VSCode Extension for training, optimizing and deploying tailored models on Edge platforms using AutoML (uses [Kenning ML framework](https://github.com/antmicro/kenning)).
 - [Eclipse Aidge](https://gitlab.eclipse.org/eclipse/aidge/aidge) - Open-source framework for optimizing and deploying deep neural networks on embedded systems.
-- [ForestHub.ai](https://foresthub.ai) - Platform for building, deploying and orchestrating embedded and edge AI agents on machines, controllers and industrial edge devices. Visual builder, local runtime, generated embedded code, hybrid edge-cloud orchestration.
+- [edge-agents (ForestHub)](https://github.com/ForestHubAI/edge-agents) - Open-source (AGPL-3.0) 30 MB AI agent runtime for edge devices. Offline by default; GPIO/UART/MQTT as first-class nodes; local SLMs alongside cloud LLMs. Runs on Raspberry Pi 5, Jetson Orin Nano, STM32MP25, ctrlX CORE.
 
 # Other interesting resources
 - [Benchmarking Edge Computing (May 2019)](https://medium.com/@aallan/benchmarking-edge-computing-ce3f13942245)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ A curated list of hardware, software, frameworks and other resources for Artific
 - [micro:bit CreateAI](https://createai.microbit.org/) - Web-based tool to train an ML model and then run it on a BBC micro:bit V2.
 - [AutoML VS Code Extension](https://github.com/analogdevicesinc/automl-embedded) - Open Source VSCode Extension for training, optimizing and deploying tailored models on Edge platforms using AutoML (uses [Kenning ML framework](https://github.com/antmicro/kenning)).
 - [Eclipse Aidge](https://gitlab.eclipse.org/eclipse/aidge/aidge) - Open-source framework for optimizing and deploying deep neural networks on embedded systems.
+- [ForestHub.ai](https://foresthub.ai) - Platform for building, deploying and orchestrating embedded and edge AI agents on machines, controllers and industrial edge devices. Visual builder, local runtime, generated embedded code, hybrid edge-cloud orchestration.
 
 # Other interesting resources
 - [Benchmarking Edge Computing (May 2019)](https://medium.com/@aallan/benchmarking-edge-computing-ce3f13942245)


### PR DESCRIPTION
## Summary

Adds one entry under **Software** for [ForestHub.ai](https://foresthub.ai) — a platform for building, deploying and orchestrating embedded and edge AI agents on machines, controllers and industrial edge devices.

## Why this fits

Sits alongside existing entries like Edge Impulse, Imagimob and Eclipse Aidge — interactive platforms targeting MCUs and edge devices — but focuses on the agent dimension (visual builder, local runtime, generated embedded code, hybrid edge-cloud).

## Disclosure

I'm affiliated with ForestHub.ai. Happy to adjust the wording or omit if you'd prefer.

Single commit, short unbiased description per the contributing guide. Thanks for maintaining the list.